### PR TITLE
Add docs for c,c++,d,j

### DIFF
--- a/sites/docs.txt
+++ b/sites/docs.txt
@@ -64,6 +64,10 @@ https://erlang.org
 https://raspberrypi.org
 https://openssl.org
 http://hyperpolyglot.org
+https://code.jsoftware.com/wiki/Main_Page
+https://en.cppreference.com/w/
+https://dpldocs.info/
+https://dlang.org/spec/spec.html
 
 # .NET
 https://fsharp.org


### PR DESCRIPTION
One of the d websites (dpldocs.info) is an unofficial library reference.  Can change it out for the official one (https://dlang.org/phobos/) if wanted, but it's made by a prominent community and is generally better.